### PR TITLE
feat(scheduler): add TCP socket support for Kubernetes inter-pod comm…

### DIFF
--- a/btu/btu_api/scheduler.py
+++ b/btu/btu_api/scheduler.py
@@ -62,48 +62,79 @@ class SchedulerAPI():
 
 	def _send_message_to_scheduler_socket(self, message, debug=False):
 		"""
-		Establish a connection to the BTU scheduler daemon's Unix Domain Socket, and send a message.
+		Establish a connection to the BTU scheduler daemon and send a message.
+		Supports both Unix Domain Socket (local) and TCP (Kubernetes).
 		"""
 		if not isinstance(message, str):
 			raise TypeError("Argument 'message' must be a UTF-8 string.")
 
+		# Check if TCP is enabled
+		use_tcp = frappe.db.get_single_value("BTU Configuration", "use_tcp_socket")
+
+		if use_tcp:
+			return self._send_via_tcp(message, debug)
+		else:
+			return self._send_via_unix_socket(message, debug)
+
+	def _send_via_tcp(self, message, debug=False):
+		"""Send message via TCP socket."""
+		tcp_host = frappe.db.get_single_value("BTU Configuration", "tcp_host")
+		tcp_port = frappe.db.get_single_value("BTU Configuration", "tcp_port")
+
+		if not tcp_host or not tcp_port:
+			raise ValueError("BTU Configuration is missing TCP host or port.")
+
+		try:
+			scheduler_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+			scheduler_socket.settimeout(5)
+			scheduler_socket.connect((tcp_host, int(tcp_port)))
+			if debug:
+				print(f"Connected to BTU Scheduler via TCP at {tcp_host}:{tcp_port}")
+		except Exception as ex:
+			return f"Exception while connecting to BTU Scheduler via TCP: {str(ex)}"
+
+		return self._send_and_receive(scheduler_socket, message, debug)
+
+	def _send_via_unix_socket(self, message, debug=False):
+		"""Send message via Unix Domain Socket."""
 		socket_str = frappe.db.get_single_value("BTU Configuration", "path_to_btu_scheduler_uds")
 		if not socket_str:
 			raise ValueError("BTU Configuration is missing a path to the Unix Domain Socket for the scheduler daemon.")
 
-		# Create a UDS socket; connect to the port where the BTU Scheduler daemon is listening.
 		socket_path = pathlib.Path(socket_str)
 		if not socket_path.exists():
-			raise FileNotFoundError(f"Path to socket file does not exists: '{socket_path.absolute()}'")
+			raise FileNotFoundError(f"Path to socket file does not exist: '{socket_path.absolute()}'")
 
 		try:
 			scheduler_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-			scheduler_socket.settimeout(5)  # Very important, otherwise indefinite wait time.
+			scheduler_socket.settimeout(5)
 			scheduler_socket.connect(str(socket_path.absolute()))
 			if debug:
 				print(f"Connected to BTU Scheduler daemon via Unix Domain Socket at '{socket_path}'")
-				print(f"Blocking: {scheduler_socket.getblocking()}")
-				print(f"Timeout: {scheduler_socket.gettimeout()}")
 		except Exception as ex:
 			return f"Exception while connecting to BTU Scheduler socket: {str(ex)}"
 
+		return self._send_and_receive(scheduler_socket, message, debug)
+
+	def _send_and_receive(self, scheduler_socket, message, debug=False):
+		"""Common send/receive logic for both socket types."""
 		message_bytes = message.encode('utf-8')
-		uds_response = None
+		response = None
 		try:
 			bytes_sent = scheduler_socket.send(message_bytes)
 			if debug:
-				print(f"Transmitted this quantity of bytes to UDS server: {bytes_sent}")
+				print(f"Transmitted bytes: {bytes_sent}")
 			time.sleep(0.5)  # brief wait for server to reply
-			uds_response = scheduler_socket.recv(2048)  # response should be much smaller than 2kb
+			response = scheduler_socket.recv(2048)
 			if debug:
-				print(f"Response (as bytes) from BTU Scheduler: {uds_response}")
+				print(f"Response from BTU Scheduler: {response}")
 		except Exception as ex:
-			print(f"Exception while communicating with the BTU Scheduler daemon's Unix Domain Socket: {ex}")
+			print(f"Exception during communication: {ex}")
 		finally:
 			scheduler_socket.close()
 			if debug:
 				print("Socket connection to BTU Scheduler daemon is now closed.")
 
-		if uds_response:
-			uds_response = uds_response.decode('utf-8')  # return UTF-8 string
-		return uds_response
+		if response:
+			response = response.decode('utf-8')
+		return response

--- a/btu/btu_core/doctype/btu_configuration/btu_configuration.json
+++ b/btu/btu_core/doctype/btu_configuration/btu_configuration.json
@@ -10,6 +10,9 @@
  "field_order": [
   "btu_scheduler_section",
   "path_to_btu_scheduler_uds",
+  "use_tcp_socket",
+  "tcp_host",
+  "tcp_port",
   "cron_time_zone",
   "cb2",
   "tests",
@@ -112,7 +115,31 @@
    "description": "This is the absolute path to the BTU Scheduler daemon's Unix Domain Socket.  Example:  /tmp/btu_scheduler.sock\n",
    "fieldname": "path_to_btu_scheduler_uds",
    "fieldtype": "Data",
-   "label": "Path to BTU Scheduler Unix socket"
+   "label": "Path to BTU Scheduler Unix socket",
+   "depends_on": "eval:!doc.use_tcp_socket"
+  },
+  {
+   "default": "0",
+   "description": "Enable TCP socket instead of Unix Domain Socket (required for Kubernetes inter-pod communication)",
+   "fieldname": "use_tcp_socket",
+   "fieldtype": "Check",
+   "label": "Use TCP Socket"
+  },
+  {
+   "default": "localhost",
+   "description": "Hostname or IP of BTU Scheduler (e.g., f2p-erp-btu-scheduler for Kubernetes)",
+   "fieldname": "tcp_host",
+   "fieldtype": "Data",
+   "label": "TCP Host",
+   "depends_on": "use_tcp_socket"
+  },
+  {
+   "default": "8888",
+   "description": "TCP port for BTU Scheduler communication",
+   "fieldname": "tcp_port",
+   "fieldtype": "Int",
+   "label": "TCP Port",
+   "depends_on": "use_tcp_socket"
   },
   {
    "description": "Sends a 'ping' request to the BTU Scheduler background daemon.",


### PR DESCRIPTION
…unication

Add configuration options and implementation for TCP socket connections to BTU scheduler daemon, enabling communication across Kubernetes pods.

Changes:
- Add use_tcp_socket, tcp_host, tcp_port fields to BTU Configuration DocType
- Refactor SchedulerAPI to support both Unix Domain Socket and TCP
- Add conditional field visibility based on socket type selection

This complements the Helm chart TCP support (PR #730) to enable cancel/reload task schedule operations in Kubernetes deployments.

Closes: #116